### PR TITLE
[Cache] 오찌(오지훈) 실습 제출합니다.

### DIFF
--- a/cache/src/main/java/com/example/cachecontrol/CacheControlInterceptor.java
+++ b/cache/src/main/java/com/example/cachecontrol/CacheControlInterceptor.java
@@ -1,0 +1,25 @@
+package com.example.cachecontrol;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+public class CacheControlInterceptor implements HandlerInterceptor {
+
+    @Override
+    public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler,
+                           final ModelAndView modelAndView) {
+        removeHeuristicCache(response);
+    }
+
+    private void removeHeuristicCache(final HttpServletResponse response) {
+        final String cacheControl = CacheControl
+                .noCache()
+                .cachePrivate()
+                .getHeaderValue();
+        response.addHeader(HttpHeaders.CACHE_CONTROL, cacheControl);
+    }
+}

--- a/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
+++ b/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
@@ -9,5 +9,8 @@ public class CacheWebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new CacheControlInterceptor());
     }
+
+
 }

--- a/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
+++ b/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
@@ -1,5 +1,8 @@
 package com.example.cachecontrol;
 
+import static com.example.version.CacheBustingWebConfig.PREFIX_STATIC_RESOURCES;
+
+import com.example.version.ResourceVersion;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,10 +10,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CacheWebConfig implements WebMvcConfigurer {
 
-    @Override
-    public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(new CacheControlInterceptor());
+    private final ResourceVersion version;
+
+    public CacheWebConfig(final ResourceVersion version) {
+        this.version = version;
     }
 
-
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new CacheControlInterceptor())
+                .excludePathPatterns(PREFIX_STATIC_RESOURCES + "/" + version.getVersion() + "/**");
+    }
 }

--- a/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
+++ b/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
@@ -1,12 +1,19 @@
 package com.example.etag;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 @Configuration
 public class EtagFilterConfiguration {
 
-//    @Bean
-//    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
-//        return null;
-//    }
+    @Bean
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        FilterRegistrationBean<ShallowEtagHeaderFilter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
+        ShallowEtagHeaderFilter shallowEtagHeaderFilter = new ShallowEtagHeaderFilter();
+        filterFilterRegistrationBean.setFilter(shallowEtagHeaderFilter);
+        filterFilterRegistrationBean.addUrlPatterns("/etag");
+        return filterFilterRegistrationBean;
+    }
 }

--- a/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
+++ b/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
@@ -1,5 +1,8 @@
 package com.example.etag;
 
+import static com.example.version.CacheBustingWebConfig.PREFIX_STATIC_RESOURCES;
+
+import com.example.version.ResourceVersion;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,12 +11,18 @@ import org.springframework.web.filter.ShallowEtagHeaderFilter;
 @Configuration
 public class EtagFilterConfiguration {
 
+    private final ResourceVersion version;
+
+    public EtagFilterConfiguration(final ResourceVersion version) {
+        this.version = version;
+    }
+
     @Bean
     public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
-        FilterRegistrationBean<ShallowEtagHeaderFilter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
-        ShallowEtagHeaderFilter shallowEtagHeaderFilter = new ShallowEtagHeaderFilter();
-        filterFilterRegistrationBean.setFilter(shallowEtagHeaderFilter);
-        filterFilterRegistrationBean.addUrlPatterns("/etag");
+        FilterRegistrationBean<ShallowEtagHeaderFilter> filterFilterRegistrationBean
+                = new FilterRegistrationBean<>(new ShallowEtagHeaderFilter());
+        filterFilterRegistrationBean.addUrlPatterns("/etag",
+                PREFIX_STATIC_RESOURCES + "/" + version.getVersion() + "/*");
         return filterFilterRegistrationBean;
     }
 }

--- a/cache/src/main/java/com/example/version/CacheBustingWebConfig.java
+++ b/cache/src/main/java/com/example/version/CacheBustingWebConfig.java
@@ -1,7 +1,9 @@
 package com.example.version;
 
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -9,6 +11,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class CacheBustingWebConfig implements WebMvcConfigurer {
 
     public static final String PREFIX_STATIC_RESOURCES = "/resources";
+    public static final int ONE_YEAR = 31_536_000;
 
     private final ResourceVersion version;
 
@@ -19,7 +22,12 @@ public class CacheBustingWebConfig implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(final ResourceHandlerRegistry registry) {
+        CacheControl cacheControl = CacheControl
+                .maxAge(Duration.ofSeconds(ONE_YEAR))
+                .cachePublic();
         registry.addResourceHandler(PREFIX_STATIC_RESOURCES + "/" + version.getVersion() + "/**")
-                .addResourceLocations("classpath:/static/");
+                .addResourceLocations("classpath:/static/")
+                .setCacheControl(cacheControl)
+                .resourceChain(true);
     }
 }

--- a/cache/src/main/resources/application.yml
+++ b/cache/src/main/resources/application.yml
@@ -1,2 +1,7 @@
 handlebars:
   suffix: .html
+
+server:
+  compression:
+    enabled: true
+    min-response-size: 10


### PR DESCRIPTION
# 학습 내용
## Cache-Control
캐싱 정첵을 결정하는 헤더
### 왜 휴리스틱 캐싱을 막으려면 Cache-Control: no-cache, private를 주어야 하는가?
응답에 `Cache-Control: max-age`가 없어도 휴리스틱으로 캐시 만료 기간을 예측하여 캐싱을 한다(휴리스틱 캐싱). 때문에 `no-cache` 옵션을 주어서 아예 캐싱을 하지 못하도록 설정해주어야 한다. `private`는 공유 캐시에 저장되지 않도록 하여 개인정보 유출 등을 방지한다.
### no-cache와 no-store의 차이점
`no-cache`는 캐시를 저장은 하지만 클라이언트에 보여주기 이전에 반드시 서버로 재검증 요청을 보내도록 한다. `no-store`는 캐시 저장 자체를 하지 않는다.
### max-age
캐시의 최대 유효 기간을 지정한다.
## HTTP Compression
HTTP 응답을 압축해서 보낼 수 있다.
### 스프링부트 설정
`application.properties` 또는 `application.yml` 파일에 압축 설정을 지정할 수 있다. 
```yaml
server:
  compression:
    enabled: true
    min-response-size: 10
```
`server.compression.enabled=true` 설정을 하게 되면 HTTP 응답을 `gzip`으로 응답하게 된다. `min-response-size`는 압축을 할 최소 크기를 나타낸다.
## ETag
특정 버전의 리소스를 식별하는 헤더로, 캐싱을 사용해도 될 지 판단하는데 사용한다.
- `If-Modified-Since`를 확인하는 방법도 있지만, `If-Modified-Since`가 초 단위 까지만 체크할 수 있기 때문에 `초보다 작은 간격으로 갱신돼 1초 정밀도가 충분하지 않은 경우`에 부적합하다. 또한 시간으로 체크를 하기 때문에 `일정 시간간격으로 다시 써지지만, 실제로는 같은 데이터를 포함하고 있는 경우`에도 부적합하다.
- 이런 경우 `If-Modified-Since` 대신 `ETag`를 사용하는 것이 권장된다.
스프링에서는 ETag를 설정하기 위한 `ShallowEtagHeaderFilter` 클래스를 제공한다.
```java
@Bean
public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
    FilterRegistrationBean<ShallowEtagHeaderFilter> filterFilterRegistrationBean
            = new FilterRegistrationBean<>(new ShallowEtagHeaderFilter());
    filterFilterRegistrationBean.addUrlPatterns("/etag", "/resources/" + version.getVersion() + "/*");
    return filterFilterRegistrationBean;
}
```
주의할 점으로, `FilterRegistrationBean`의 `addUrlPatterns`는 스프링 URL 패턴을 사용하는 것이 아니라 서블릿의 URL 패턴을 사용하기 때문에 스프링에서 URL 패턴을 설정할 때와 조금 다르다.
## If-None-Match
서버에 최초로 요청 시에는 ETag 값이 없으며, 서버에서 응답을 내려줄 때 헤더에 ETag 값이 들어있다. 이후 재차 요청을 할 때 ETag를 `If-None-Match` 헤더에 담아 서버로 보내주게 된다. 서버가 가지고 있는 ETag 값과 If-None-Match 값이 일치하면 `304 Not Modified`를 반환해서 캐싱된 데이터를 그대로 쓸 수 있도록 하고, 일치하지 않을 경우 `200 Ok`와 함께 새로운 응답을 내려준다.
## Cache Busting
정적 리소스 파일에 캐싱을 적용하긴 하지만, JS나 CSS 파일처럼 자주 바뀌는 경우 리소스가 수정되면 캐싱되어 있는 자료가 아닌 새로운 파일을 보도록 해야 한다. 그런데 캐시는 URL을 기반으로 리소스를 구분하므로 리소스가 업데이트될 때 URL을 변경하면 손쉽게 JS, CSS 파일의 캐시를 제거할 수 있다.
- JS나 CSS 파일이 수정될 때마다 URL에 새로운 해시 값을 넣어 주면 된다.
- ex) `/resources/{version}/js/index.js`